### PR TITLE
Don't handle DESTROY with AUTOLOAD

### DIFF
--- a/lib/Supervisord/Client.pm
+++ b/lib/Supervisord/Client.pm
@@ -81,12 +81,15 @@ sub AUTOLOAD {
     my ( $self, @args ) = @_;
     $self->send_rpc_request("supervisor.$remote_method", @args );
 }
+
 sub send_rpc_request {
     my( $self, @params ) = @_;
     my $ret = $self->rpc->send_request( @params );
     return $ret->value if $ret->$_can("value");
     return $ret;
 }
+
+sub DESTROY {}
 
 1;
 

--- a/t/destroy.t
+++ b/t/destroy.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Test::More;
+plan tests => 1;
+
+use Supervisord::Client;
+
+BEGIN {
+    package Test::RPC::XML::Client;
+    sub new {
+        bless {}, shift;
+    }
+
+    sub send_request {
+        my $self   = shift;
+        my $method = shift;
+        push @{$self->{requests}}, $method;
+    }
+}
+
+my $rpc = Test::RPC::XML::Client->new;
+
+{
+    my $client = Supervisord::Client->new(
+        serverurl => 'http://supervisor:9001',
+        rpc       => $rpc,
+    );
+
+    $client->getAllProcessInfo;
+}
+
+is_deeply(
+    $rpc->{requests},
+    ['supervisor.getAllProcessInfo'],
+    'object destruction does not result in RPC call to supervisor.DESTROY'
+);
+
+done_testing;


### PR DESCRIPTION
When the last reference to a Supervisord::Client object goes away, its `DESTROY` method is called.  Because no `DESTROY` method is defined, its `AUTOLOAD` method handles it instead.  This results in an RPC call to `supervisor.DESTROY` - a method which does not exist in Supervisor. This could cause problems if such a method is ever implemented.  It also causes problems if, for example, the RPC calls are made through an SSH tunnel which is destroyed at object destruction, before the Supervisord::Client object is destroyed.

Note that due to a bug introduced into Perl somewhere between 5.14.2 and 5.18.2, `AUTOLOAD` was is not called to handle the `DESTROY` method:

https://rt.perl.org/Public/Bug/Display.html?id=124387

The problem has been fixed in Perl 5.24.0:

http://perldoc.perl.org/perl5240delta.html#Selected-Bug-Fixes

The included patch and test should pass against correct and incorrect versions of Perl.