### PR TITLE
remove unhandled import arguments

### DIFF
--- a/lib/Supervisord/Client.pm
+++ b/lib/Supervisord/Client.pm
@@ -2,7 +2,7 @@ package Supervisord::Client;
 use strict;
 use warnings;
 use LWP::Protocol::http::SocketUnixAlt;
-use RPC::XML::Client qw[ $RPC::XML::ERROR ];
+use RPC::XML::Client;
 use Moo::Lax;
 use Carp;
 use Safe::Isa;


### PR DESCRIPTION
Previous versions of perl allow a use or import call even if the import method doesn't exist. Future versions are intending to throw errors for calls to an undefined import method that includes arguments.

Remove the arguments to use lines when the import method does not exist.